### PR TITLE
Fix HTML relative resource resolution in iframe preview.

### DIFF
--- a/src/HtmlPluginSettings.ts
+++ b/src/HtmlPluginSettings.ts
@@ -137,11 +137,18 @@ export class HtmlSettingTab extends PluginSettingTab {
 	
 	buildHotkeySettings(): void {
 		const { containerEl } = this;
+		const appAny = this.app as App & { hotkeyManager?: any; isMobile?: boolean };
+		const getHotkeysSafe = (commandId: string): any[] => {
+			const manager = appAny.hotkeyManager;
+			if (!manager)
+				return [];
+			return manager.getHotkeys?.(commandId) || manager.getDefaultHotkeys?.(commandId) || [];
+		};
 		
 		// default hotkeys: app.commands.commands app.hotkeyManager.defaultKeys
 		// custom hotkeys: app.hotkeyManager.customKeys
 		
-		let gSearch = this.app.hotkeyManager.getHotkeys('editor:open-search') || this.app.hotkeyManager.getDefaultHotkeys('editor:open-search');
+		let gSearch = getHotkeysSafe('editor:open-search');
 		const hkSearch = new Setting(containerEl);
 		hkSearch
 			.setName( "Search document text" )
@@ -152,22 +159,22 @@ export class HtmlSettingTab extends PluginSettingTab {
 			{ elm: hkSearch, settings: gSearch } 
 		];
 			
-		if( !this.app.isMobile ) {
+		if( !appAny.isMobile ) {
 			// following Hotkey settings would not appear on Mobile platforms!!
 			
-			let gZoomIn = this.app.hotkeyManager.getHotkeys('window:zoom-in') || this.app.hotkeyManager.getDefaultHotkeys('window:zoom-in');
+			let gZoomIn = getHotkeysSafe('window:zoom-in');
 			const hkZoomIn = new Setting(containerEl)
 								.setName( "Zoom in document" )
 								.setDesc( `Zoom in current file.` );
 			hotkeyPairs.push( { elm: hkZoomIn, settings: gZoomIn } );
 			
-			let gZoomOut = this.app.hotkeyManager.getHotkeys('window:zoom-out') || this.app.hotkeyManager.getDefaultHotkeys('window:zoom-out');
+			let gZoomOut = getHotkeysSafe('window:zoom-out');
 			const hkZoomOut = new Setting(containerEl)
 								.setName( "Zoom out document" )
 								.setDesc( `Zoom out current file.` );
 			hotkeyPairs.push( { elm: hkZoomOut, settings: gZoomOut } );
 								
-			let gZoomReset = this.app.hotkeyManager.getHotkeys('window:reset-zoom') || this.app.hotkeyManager.getDefaultHotkeys('window:reset-zoom');
+			let gZoomReset = getHotkeysSafe('window:reset-zoom');
 			const hkZoomReset = new Setting(containerEl)
 								.setName( "Reset document zoom" )
 								.setDesc( `Reset current file zoom.` );

--- a/src/HtmlView.ts
+++ b/src/HtmlView.ts
@@ -65,11 +65,13 @@ export class HtmlView extends FileView {
 			this.mainView.innerHTML = MAINVIEW_HTML; // direct assign safe HTML code
 			const searchBar = this.mainView.querySelector( "#ohpMainView" );
 			const iframe = this.mainView.querySelector( "#ohpIframe" );
+			const baseHref = getHtmlBaseHref(this.app, file);
 			
 			let dom = null, applyAnchorFix = true;
 			switch( this.settings.opMode ) {
 				case HtmlPluginOpMode.Balance:
 					dom = (new window.DOMParser()).parseFromString( htmlStr, 'text/html' );
+					ensureBaseHref(dom, baseHref);
 					await removeScriptTagsAndExtScripts( dom );
 					await sanitizeAndApplyPatches( dom );
 					await restoreStateBySettings( dom, this.settings );
@@ -80,26 +82,27 @@ export class HtmlView extends FileView {
 				
 				case HtmlPluginOpMode.LowRestricted:
 					dom = (new window.DOMParser()).parseFromString( htmlStr, 'text/html' );
+					ensureBaseHref(dom, baseHref);
 					await removeScriptTagsAndExtScripts( dom );
 					await restoreStateBySettings( dom, this.settings );
 					iframe.srcdoc = dom.documentElement.outerHTML;
 					break;
 				
 				case HtmlPluginOpMode.Unrestricted:
-					iframe.srcdoc = htmlStr;
+					iframe.srcdoc = injectBaseHrefToHtml(htmlStr, baseHref);
 					break;
 				
 				case HtmlPluginOpMode.HighRestricted:
 					const purifier = new window.DOMPurify();
 					purifier.addHook( 'afterSanitizeAttributes' , ohpAfterSanitizeAttributes ); // disable some elements to avoid XSS attacks
-					const cleanHtmlHR = purifier.sanitize( htmlStr, hrModeConfig );
+					const cleanHtmlHR = purifier.sanitize( injectBaseHrefToHtml(htmlStr, baseHref), hrModeConfig );
 					// iframe.sandbox = "allow-forms allow-modals allow-pointer-lock allow-popups allow-presentation allow-top-navigation-by-user-activation";
 					iframe.csp = "default-src 'none'; script-src 'none'; object-src 'none'; frame-src https: http: mediastream: blob:; font-src 'self' data:; img-src 'self' data:; style-src 'unsafe-inline'; media-src 'self' data:; "; 
 					iframe.srcdoc = cleanHtmlHR;
 					break;
 									
 				case HtmlPluginOpMode.Text:
-					const cleanHtmlText = (new window.DOMPurify()).sanitize( htmlStr, textModeConfig );
+					const cleanHtmlText = (new window.DOMPurify()).sanitize( injectBaseHrefToHtml(htmlStr, baseHref), textModeConfig );
 					iframe.sandbox = "allow-same-origin";
 					iframe.csp = "default-src 'none'; script-src 'none'; object-src 'none'; frame-src 'none'; font-src 'self' data:; img-src 'none'; style-src 'unsafe-inline'; media-src 'none'; ";
 					iframe.srcdoc = cleanHtmlText;
@@ -191,6 +194,36 @@ export class HtmlView extends FileView {
 	getIcon() {
 		// built-in icons list: https://forum.obsidian.md/t/list-of-available-icons-for-component-seticon/16332
 		return "code-glyph";  // </>
+	}
+}
+
+function getHtmlBaseHref(app: App, file: TFile): string {
+	try {
+		const resourcePath = app?.vault?.getResourcePath(file);
+		return resourcePath || "";
+	} catch {
+		return "";
+	}
+}
+
+function ensureBaseHref(doc: Document, baseHref: string): void {
+	if (!doc?.head || !baseHref) return;
+	let baseElm = doc.querySelector("base");
+	if (!baseElm) {
+		baseElm = doc.createElement("base");
+		doc.head.prepend(baseElm);
+	}
+	baseElm.setAttribute("href", baseHref);
+}
+
+function injectBaseHrefToHtml(htmlStr: string, baseHref: string): string {
+	if (!htmlStr || !baseHref) return htmlStr;
+	try {
+		const doc = (new window.DOMParser()).parseFromString(htmlStr, "text/html");
+		ensureBaseHref(doc, baseHref);
+		return doc.documentElement.outerHTML;
+	} catch {
+		return htmlStr;
 	}
 }
 
@@ -409,7 +442,9 @@ function isUnselectableElement( elm: HTMLElement ): boolean {
 
 let isAppleSys = isMacPlatform() || isIosPlatform();
 function mapNativeHotkeys( app: App, cmdId: string ): Hotkey[] {
-	let ohks = app.hotkeyManager.getHotkeys(cmdId) || app.hotkeyManager.getDefaultHotkeys(cmdId);
+	const appAny = app as App & { hotkeyManager?: any };
+	const manager = appAny.hotkeyManager;
+	let ohks = manager?.getHotkeys?.(cmdId) || manager?.getDefaultHotkeys?.(cmdId);
 
 	const nhks: Hotkey[] = [];
 	if( !ohks || ohks.length <= 0 )


### PR DESCRIPTION
Inject a base href derived from the current HTML file so relative image/style/script URLs resolve correctly in srcdoc mode, and add hotkey manager access guards for newer Obsidian type definitions.