### PR TITLE
Fix: prevent horizontal scroll in HTML view and settings

### DIFF
--- a/src/HtmlPluginOpMode.ts
+++ b/src/HtmlPluginOpMode.ts
@@ -50,6 +50,7 @@ export const OP_MODE_INFO_HTML: string = `
 
 <details>
 <summary>Comparison</summary>
+<div style="overflow-x: auto; max-width: 100%; -webkit-overflow-scrolling: touch;">
 <table id="ophCompTable">
   <thead>
   <tr>
@@ -116,6 +117,7 @@ export const OP_MODE_INFO_HTML: string = `
   </tr>
   <tbody>
 </table>
+</div>
 
 <div><b>*</b>: <a href="https://web.dev/declarative-shadow-dom/">Declarative Shadow DOM</a></div>
 <div><b>#</b>: <a href="https://en.wikipedia.org/wiki/Content_Security_Policy">Content Security Policy</a></div>

--- a/src/HtmlPluginSettings.ts
+++ b/src/HtmlPluginSettings.ts
@@ -38,7 +38,7 @@ export class HtmlSettingTab extends PluginSettingTab {
 		containerEl.empty();
 		containerEl.createEl('h1', { text: 'HTML Reader Settings' });
 		containerEl.createEl('pre', { text: '※ Remember to reload the file after changing any setting.'})
-						.setAttribute('style', 'color:red');
+						.setAttribute('style', 'color:red; white-space: pre-wrap; word-break: break-word;');
 			
 		// ----- General Settings -----
 		containerEl.createEl('h2', { text: 'General Settings' });

--- a/src/HtmlView.ts
+++ b/src/HtmlView.ts
@@ -347,16 +347,25 @@ async function sanitizeAndApplyPatches( doc: HTMLDocument ): Promise<void> {
 
 function applyUserInteractivePatches( doc: HTMLDocument ) {
 	if( !doc.body.style ) {
-		doc.body.setAttribute( 'style', "overflow: auto; user-select: text;" );
+		doc.body.setAttribute( 'style', "overflow-x: hidden; overflow-y: auto; user-select: text; max-width: 100%; word-wrap: break-word;" );
 		return;
 	}
 	
 	// avoid some HTML files unable to scroll, only when 'overflow' is not set
-	if( doc.body.style.overflow === '' )
-		doc.body.style.overflow = 'auto';
+	if( doc.body.style.overflow === '' ) {
+		doc.body.style.overflowX = 'hidden';
+		doc.body.style.overflowY = 'auto';
+	}
+	// avoid horizontal overflow on any element
+	if( doc.body.style.maxWidth === '' )
+		doc.body.style.maxWidth = '100%';
 	// avoid some HTML files unable to select text, only when 'user-select' is not set
 	if( doc.body.style.userSelect === '' )
 		doc.body.style.userSelect = 'text';
+	
+	// also constrain html root element
+	if( doc.documentElement.style.overflowX === '' )
+		doc.documentElement.style.overflowX = 'hidden';
 }
 
 async function removeScriptTagsAndExtScripts( doc: HTMLDocument ): Promise<void> {
@@ -1038,7 +1047,7 @@ const MAINVIEW_HTML: string = `
   </div>
 </div>
 
-<iframe style="border: none; flex-grow: 1; width: 100%; overflow: hidden;" loading="eager" margin="0" padding="0"  width="100%" height="100%" id="ohpIframe">
+<iframe style="border: none; flex-grow: 1; width: 100%; overflow-x: hidden; overflow-y: auto;" loading="eager" margin="0" padding="0"  width="100%" height="100%" id="ohpIframe">
 </iframe>
 `;
 


### PR DESCRIPTION
## Summary

Prevent unwanted horizontal scrolling in two places: the HTML file viewer and the plugin settings page. Both are most noticeable on narrow screens and touch devices (iOS/Android).

## Problem

**1. HTML file viewer** — The iframe allows horizontal scroll, causing accidental side-swipes on touch devices. Obsidian's reading pane is narrow; users expect vertical-only scrolling.

**2. Settings page** — The operating mode comparison table (8 columns) is injected as raw HTML (`createContextualFragment`) and overflows on narrow screens. The `<pre>` warning text also doesn't wrap.

This is specific to the HTML Reader plugin because it injects raw HTML into the settings page (the comparison table). Most other Obsidian plugins use native `Setting` components which are automatically width-constrained.

## Changes

| File | Change |
|------|--------|
| `src/HtmlView.ts` | `applyUserInteractivePatches`: `overflow: auto` → `overflow-x: hidden; overflow-y: auto`. Add `max-width: 100%` and `<html>` root element constraint. iframe style: `overflow: hidden` → `overflow-x: hidden; overflow-y: auto`. |
| `src/HtmlPluginSettings.ts` | `<pre>` warning: add `white-space: pre-wrap; word-break: break-word;` |
| `src/HtmlPluginOpMode.ts` | Wrap comparison table in `<div style="overflow-x: auto; max-width: 100%;">` — table scrolls internally instead of pushing the page wider |

**3 files, +16 −5 lines.**

## Tradeoff

HTML files with intentionally wide content (e.g. wide tables) will scroll inside their own container rather than at the page level. This is consistent with Obsidian's reading mode behavior.