### PR TITLE
feat(reader): add native iframe mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Set Operating Mode for this plugin to protect user and app.
 | **Balance Mode**         | Yes    | Yes     | No                    | Yes              | Yes | Yes | Yes |
 | **Low Restricted Mode**  | Yes    | Yes     | Partial<sup>[2]</sup> | Yes              | No  | No  | Yes |
 | **Unrestricted Mode**    | Yes    | Yes     | Yes<sup>[3]</sup>     | Yes              | No  | No  | Yes |
+| **Native iframe**        | Yes    | Yes     | Yes                   | Yes              | File-defined | No | Yes |
 
 *: [Declarative Shadow DOM](https://web.dev/declarative-shadow-dom/) <br />
 #: [Content Security Policy](https://en.wikipedia.org/wiki/Content_Security_Policy) <br />
@@ -79,6 +80,8 @@ Set Operating Mode for this plugin to protect user and app.
     Sometimes you still cannot see what you want, then you should check the content of HTML file. This mode is just leave the content alone (only <ins>adjust the external link anchor tags to let them open in default browser windows</ins>), but the file might has some self-contained security protection facilities (such as CSP) and they would block something to avoid XSS attacks. If you find something like `<meta http-equiv="Content-Security-Policy" />` inside the HTML file, it means the file is protected by CSP mechanism. You might
     - Modify or remove the CSP `<meta>` tag by hands.
     - Change the capture settings of the original web page saving app to disable CSP or something else, and re-save the web page.
+
+6. **Native iframe** - Desktop only. This mode navigates a sandboxed iframe directly to the selected local HTML resource, allowing the document's own JavaScript and relative resources to run. Use it only for local HTML files you trust. HTML Reader does not sanitize the document, and its injected search, zoom, background color, and link-rewriting features are unavailable in this mode.
 
 </details>
 <details>

--- a/src/HtmlPluginOpMode.ts
+++ b/src/HtmlPluginOpMode.ts
@@ -4,7 +4,8 @@ export const enum HtmlPluginOpMode {
 	HighRestricted = "HighRestrictedMode",
 	Balance = "BalanceMode",
 	LowRestricted = "LowRestrictedMode",
-	Unrestricted = "UnestrictedMode"
+	Unrestricted = "UnestrictedMode",
+	Native = "NativeMode"
 }
 
 export const OP_MODE_INFO_DATA: Record<string, string> = {
@@ -12,7 +13,8 @@ export const OP_MODE_INFO_DATA: Record<string, string> = {
 	[HtmlPluginOpMode.HighRestricted]: "High Restricted Mode",
 	[HtmlPluginOpMode.Balance]: "Balance Mode",
 	[HtmlPluginOpMode.LowRestricted]: "Low Restricted Mode",
-	[HtmlPluginOpMode.Unrestricted]: "Unrestricted Mode"
+	[HtmlPluginOpMode.Unrestricted]: "Unrestricted Mode",
+	[HtmlPluginOpMode.Native]: "Native iframe (trusted local files only)"
 }
 
 export const OP_MODE_INFO_HTML: string = `
@@ -115,6 +117,16 @@ export const OP_MODE_INFO_HTML: string = `
 	<td> No </td>
 	<td> Yes </td>
   </tr>
+  <tr>
+	<td><span> Native iframe </span></td>
+	<td> Yes </td>
+	<td> Yes </td>
+	<td> Yes </td>
+	<td> Yes </td>
+	<td> File-defined </td>
+	<td> No </td>
+	<td> Yes </td>
+  </tr>
   <tbody>
 </table>
 </div>
@@ -149,6 +161,7 @@ export const OP_MODE_INFO_HTML: string = `
 	  <li>Change the capture settings of the original web page saving app to disable CSP or something else, and re-save the web page.</li>
 	</ul>
   </li>
+  <li><b style="color: red;">Native iframe</b> - Desktop only. Loads the selected local HTML file directly in a sandboxed iframe so its own JavaScript and relative resources can run. Use this mode only for local HTML files you trust. HTML Reader's injected search, zoom, background color, and link-rewriting features are unavailable in this mode.</li>
 </ol>
 </details>
 `;

--- a/src/HtmlView.ts
+++ b/src/HtmlView.ts
@@ -1,4 +1,4 @@
-import { WorkspaceLeaf, FileView, TFile, sanitizeHTMLToDom, setIcon, Notice } from "obsidian";
+import { WorkspaceLeaf, FileView, TFile, sanitizeHTMLToDom, setIcon, Notice, Platform } from "obsidian";
 import { HtmlPluginSettings, isMacPlatform, isIosPlatform, DEFAULT_SETTINGS } from './HtmlPluginSettings';
 import { HtmlPluginOpMode } from './HtmlPluginOpMode';
 
@@ -32,28 +32,30 @@ export class HtmlView extends FileView {
 		this.contentEl.empty();
 	
 		try {
-			// whole HTML file ArrayBuffer
-			const contents = await this.app.vault.readBinary(file);
-			
-			// Obsidian's HTMLElement and Node API: https://github.com/obsidianmd/obsidian-api/blob/master/obsidian.d.ts
-			
+			const isNativeMode = this.settings.opMode === HtmlPluginOpMode.Native;
 			let htmlStr = null;
-			
-			if( this.settings.mhtmlSupport && (MHTML_FILE_EXTENSIONS.indexOf(file.extension) >= 0) ) {
-				// Support MHTML, Feature request #19
-				const { data, title, favicons } = await convert(new Uint8Array(contents));
-				htmlStr = data;
-			} else {
-				try {
-					// the HTML file made by SingleFileZ
-					globalThis.zip = zip;
-					const { docContent } = await extract(new Blob([new Uint8Array(contents)]), { noBlobURL: true });
-					
-					htmlStr = docContent;
-				} catch {
-					// the HTML file not made by SingleFileZ			
-					const decoder = new TextDecoder();
-					htmlStr = decoder.decode(contents); // decode with UTF8
+
+			if( !isNativeMode ) {
+				// whole HTML file ArrayBuffer
+				const contents = await this.app.vault.readBinary(file);
+
+				// Obsidian's HTMLElement and Node API: https://github.com/obsidianmd/obsidian-api/blob/master/obsidian.d.ts
+				if( this.settings.mhtmlSupport && (MHTML_FILE_EXTENSIONS.indexOf(file.extension) >= 0) ) {
+					// Support MHTML, Feature request #19
+					const { data, title, favicons } = await convert(new Uint8Array(contents));
+					htmlStr = data;
+				} else {
+					try {
+						// the HTML file made by SingleFileZ
+						globalThis.zip = zip;
+						const { docContent } = await extract(new Blob([new Uint8Array(contents)]), { noBlobURL: true });
+
+						htmlStr = docContent;
+					} catch {
+						// the HTML file not made by SingleFileZ
+						const decoder = new TextDecoder();
+						htmlStr = decoder.decode(contents); // decode with UTF8
+					}
 				}
 			}
 			
@@ -108,6 +110,16 @@ export class HtmlView extends FileView {
 					iframe.srcdoc = cleanHtmlText;
 					applyAnchorFix = false
 					break;
+
+				case HtmlPluginOpMode.Native:
+					if( !Platform.isDesktopApp )
+						throw new Error("Native iframe mode is available only in the desktop app.");
+					if( !baseHref )
+						throw new Error("Unable to resolve the local HTML resource URL.");
+					iframe!.setAttribute("sandbox", "allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-downloads");
+					iframe!.setAttribute("src", baseHref);
+					applyAnchorFix = false;
+					break;
 			}
 				
 			iframe.mainView = this.mainView;
@@ -116,6 +128,8 @@ export class HtmlView extends FileView {
 			this.mainView.searchBar = searchBar;
 			this.mainView.iframe = iframe;
 			iframe.onload = async function() {
+				if( isNativeMode )
+					return;
 				if( applyAnchorFix ) {
 					// fix some behaviors for consistency with Shadow DOM and Obsidian
 					applyUserInteractivePatches( iframe.contentDocument );
@@ -145,6 +159,10 @@ export class HtmlView extends FileView {
 	onPaneMenu(menu: Menu, source: 'more-options' | 'tab-header' | string): void {
 		if( source !== 'more-options' ) // only handle 'more-options' onMoreOptionsMenu()
 			return;
+		if( this.settings.opMode === HtmlPluginOpMode.Native ) {
+			super.onPaneMenu(menu, source);
+			return;
+		}
 
 		menu.addItem((item) => {
 			item
@@ -1135,4 +1153,3 @@ export const BM_ALLOWED_ATTRS = [
 	'async', 'charset', 'collapse', 'collapsed', 'content', 'data', 'defer', 'external', 'frameborder', 'http-equiv', 'property', 'sandbox', 'scoped', 'scrolling', 'shadowroot', 'text', 'url', 'var',
 	'aria-*', 'data-*', 'href-*', 'src-*', 'style-*',
 ];
-


### PR DESCRIPTION
## Summary

- add an explicit opt-in Native iframe operating mode for trusted local HTML files
- navigate the iframe to Obsidian's `vault.getResourcePath()` URL so document scripts and relative resources can run
- keep the existing operating modes and the default Balance mode unchanged
- skip HTML Reader's injected search, zoom, background color, and link rewriting in Native mode

## Security and limitations

Native iframe mode is desktop-only and intended only for local HTML files the user trusts. The document is not sanitized. It runs inside an iframe sandbox with scripts, same-origin resources, forms, popups, and downloads enabled.

## Test plan

- `node esbuild.config.mjs production` succeeds
- `git diff --check` succeeds
- TypeScript diagnostics match the upstream `master` baseline: 196 on both branches
- manually opened a local interactive HTML document in Obsidian and verified MathJax rendering, theme switching, TOC highlighting, and scroll progress